### PR TITLE
Trigger alert (not recovery) on unknown status

### DIFF
--- a/sensu_handler_pagerduty_alternative.py
+++ b/sensu_handler_pagerduty_alternative.py
@@ -190,7 +190,7 @@ def send_to_pd(args):
         "custom_details": args.details,
     }
 
-    if args.status in (1, 2):
+    if args.status:
         session.trigger(
             summary=args.summary,
             source=source,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='sensu-handler-pagerduty-alternative',
-    version='0.1.0',
+    version='0.2.0',
     author='Cole Tuininga',
     author_email='cole.tuininga+sensu-handler@gmail.com',
     description='A Sensu Go handler to communicate with PagerDuty',


### PR DESCRIPTION
The previous version of the code would cause any status code outside of (1, 2) to trigger a recovery.  In reality, we only want a "0" to trigger a recovery.  Everything outside of (0, 1, 2) is an "unknown" status and should be triggering an incident.  (And a sensu filter applied to weed them out, if that's truly what is desired).